### PR TITLE
config.edn is now read from file system (instead from classpath).

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ stored data from earlier releases. We do however expect to release a 1.0.0 versi
 *Note:* The current master version of VisualReview server requires Java 7 JRE or higher. The preview release however requires Java 8.
 
 * Download and extract a preview release from [here](https://github.com/xebia/VisualReview/releases).
-* Configure the environment variables in start.sh (optional)
-* Make sure that the screenshot directory exists (default is .visualreview/screenshots)
+* Reconfigure any settings in config.edn (optional)
+* Make sure that the screenshots directory exists and is readable (default is ```screenshots```)
 * Run ./start.sh
-* Open your browser at [http://localhost:7000](http://localhost:7000) (or the port you configured in start.sh)
+* Open your browser at [http://localhost:7000](http://localhost:7000) (or the port you configured in config.edn)
 * Create a new project
 
 ### Running your first test

--- a/config.edn
+++ b/config.edn
@@ -3,8 +3,8 @@
  :server-port "7000"
 
  ;; Database
- :db-uri "tcp://localhost/./visualreview"
- :db-user "sa"
+ :db-uri "file:./.visualreview/visualreview.db"
+ :db-user ""
  :db-password ""
 
  ;; File system

--- a/config.edn
+++ b/config.edn
@@ -3,8 +3,8 @@
  :server-port "7000"
 
  ;; Database
- :db-uri "file:./.visualreview/visualreview.db"
- :db-user ""
+ :db-uri "tcp://localhost/./visualreview"
+ :db-user "sa"
  :db-password ""
 
  ;; File system

--- a/src/test/clojure/com/xebia/visualreview/config_test.clj
+++ b/src/test/clojure/com/xebia/visualreview/config_test.clj
@@ -19,7 +19,7 @@
             [com.xebia.visualreview.config :refer :all]))
 
 (deftest initialisation
-  (let [parsed-config (init! "test_config.edn")]
+  (let [parsed-config (init! "src/test/resources/test_config.edn")]
     (are [key val] (= val (key parsed-config))
       :server-port 7001
       :db-uri "dummy:123//db"


### PR DESCRIPTION
This enables reading a configuration file when VisualReview server is started from a .jar.